### PR TITLE
refactor(core-token-vesting-v2)!: remove recipient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "core-token-vesting-v2"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/contracts/core-token-vesting-v2/Cargo.toml
+++ b/contracts/core-token-vesting-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-token-vesting-v2"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 description = "Token vesting contract v2"
 

--- a/contracts/core-token-vesting-v2/src/contract.rs
+++ b/contracts/core-token-vesting-v2/src/contract.rs
@@ -2,7 +2,7 @@
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     to_json_binary, Attribute, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut,
-    Env, MessageInfo, Response, StdError, StdResult, Storage, SubMsg, Timestamp,
+    Env, MessageInfo, Response, StdError, StdResult, Storage, Timestamp,
     Uint128,
 };
 use std::cmp::min;
@@ -77,7 +77,7 @@ pub fn execute(
         ExecuteMsg::DeregisterVestingAccounts { addresses } => {
             deregister_vesting_accounts(deps, env, info, addresses)
         }
-        ExecuteMsg::Claim { denoms: _denoms } => claim(deps, env, info),
+        ExecuteMsg::Claim { } => claim(deps, env, info),
         ExecuteMsg::Withdraw { amount } => withdraw(deps, env, info, amount),
     }
 }

--- a/contracts/core-token-vesting-v2/src/contract.rs
+++ b/contracts/core-token-vesting-v2/src/contract.rs
@@ -77,13 +77,8 @@ pub fn execute(
         ExecuteMsg::DeregisterVestingAccounts { addresses } => {
             deregister_vesting_accounts(deps, env, info, addresses)
         }
-        ExecuteMsg::Claim {
-            denoms: _denoms,
-            recipient,
-        } => claim(deps, env, info, recipient),
-        ExecuteMsg::Withdraw { amount, recipient } => {
-            withdraw(deps, env, info, amount, recipient)
-        }
+        ExecuteMsg::Claim { denoms: _denoms } => claim(deps, env, info),
+        ExecuteMsg::Withdraw { amount } => withdraw(deps, env, info, amount),
     }
 }
 
@@ -95,15 +90,15 @@ pub fn withdraw(
     _env: Env,
     info: MessageInfo,
     amount: Uint128,
-    recipient: String,
 ) -> Result<Response, ContractError> {
     let whitelist = WHITELIST.load(deps.storage)?;
     let mut unallocated_amount = UNALLOCATED_AMOUNT.load(deps.storage)?;
     let denom = DENOM.load(deps.storage)?;
 
-    if !whitelist.is_admin(info.sender) {
+    if !whitelist.is_admin(&info.sender) {
         return Err(StdError::generic_err("Unauthorized").into());
     }
+    let recipient = info.sender.as_str();
 
     let amount_max = min(amount, unallocated_amount);
     if amount_max.is_zero() {
@@ -113,13 +108,10 @@ pub fn withdraw(
     unallocated_amount -= amount_max;
     UNALLOCATED_AMOUNT.save(deps.storage, &unallocated_amount)?;
 
-    // validate recipient address
-    deps.api.addr_validate(&recipient)?;
-
     Ok(Response::new()
-        .add_messages(vec![build_send_msg(&denom, amount_max, &recipient)])
+        .add_messages(vec![build_send_msg(&denom, amount_max, recipient)])
         .add_attribute("action", "withdraw")
-        .add_attribute("recipient", &recipient)
+        .add_attribute("recipient", recipient)
         .add_attribute("amount", amount_max.to_string())
         .add_attribute("unallocated_amount", unallocated_amount.to_string()))
 }
@@ -320,12 +312,7 @@ fn deregister_vesting_account(
 
     // transfer already vested amount to the user
     let claimable_amount = vested_amount.checked_sub(claimed_amount)?;
-    send_if_amount_is_not_zero(
-        messages,
-        claimable_amount,
-        &denom,
-        address,
-    )?;
+    send_if_amount_is_not_zero(messages, claimable_amount, &denom, address)?;
 
     // transfer left vesting amount to the admin
     let left_vesting_amount =
@@ -366,16 +353,14 @@ fn claim(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    recipient: Option<String>,
 ) -> Result<Response, ContractError> {
-    let sender = &info.sender;
-    let recipient = &recipient.unwrap_or_else(|| sender.to_string());
+    let recipient = info.sender.as_str();
     let denom = DENOM.load(deps.storage)?;
 
     let mut attrs: Vec<Attribute> = vec![];
 
     // vesting_account existence check
-    let account = VESTING_ACCOUNTS.may_load(deps.storage, sender.as_str())?;
+    let account = VESTING_ACCOUNTS.may_load(deps.storage, recipient)?;
     if account.is_none() {
         return Err(StdError::generic_err(format!(
             "vesting entry is not found for denom {}",
@@ -395,9 +380,9 @@ fn claim(
 
     account.claimed_amount = vested_amount;
     if account.claimed_amount == account.vesting_amount {
-        VESTING_ACCOUNTS.remove(deps.storage, sender.as_str());
+        VESTING_ACCOUNTS.remove(deps.storage, recipient);
     } else {
-        VESTING_ACCOUNTS.save(deps.storage, sender.as_str(), &account)?;
+        VESTING_ACCOUNTS.save(deps.storage, recipient, &account)?;
     }
 
     attrs.extend(
@@ -412,7 +397,7 @@ fn claim(
 
     Ok(Response::new()
         .add_messages(vec![build_send_msg(&denom, claimable_amount, recipient)])
-        .add_attributes(vec![("action", "claim"), ("address", sender.as_str())])
+        .add_attributes(vec![("action", "claim"), ("address", recipient)])
         .add_attributes(attrs))
 }
 

--- a/contracts/core-token-vesting-v2/src/msg.rs
+++ b/contracts/core-token-vesting-v2/src/msg.rs
@@ -33,9 +33,7 @@ pub enum ExecuteMsg {
     },
 
     /// Claim is an operation that allows one to claim vested tokens.
-    Claim {
-        denoms: Vec<Denom>,
-    },
+    Claim {},
 
     // Withdraw allows the admin to withdraw the funds from the contract
     Withdraw {
@@ -91,7 +89,7 @@ pub enum QueryMsg {
     },
     VestingAccounts {
         address: Vec<String>,
-    }
+    },
 }
 
 #[cw_serde]

--- a/contracts/core-token-vesting-v2/src/msg.rs
+++ b/contracts/core-token-vesting-v2/src/msg.rs
@@ -35,13 +35,11 @@ pub enum ExecuteMsg {
     /// Claim is an operation that allows one to claim vested tokens.
     Claim {
         denoms: Vec<Denom>,
-        recipient: Option<String>,
     },
 
     // Withdraw allows the admin to withdraw the funds from the contract
     Withdraw {
         amount: Uint128,
-        recipient: String,
     },
 }
 

--- a/contracts/core-token-vesting-v2/src/testing.rs
+++ b/contracts/core-token-vesting-v2/src/testing.rs
@@ -793,9 +793,7 @@ fn claim_native() -> TestResult {
 
     // valid claim
     let info = mock_info("addr0001", &[]);
-    let msg = ExecuteMsg::Claim {
-        denoms: vec![],
-    };
+    let msg = ExecuteMsg::Claim {};
 
     let res = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone())?;
     assert_eq!(

--- a/contracts/core-token-vesting-v2/src/testing.rs
+++ b/contracts/core-token-vesting-v2/src/testing.rs
@@ -498,7 +498,6 @@ fn test_withdraw() -> TestResult {
 
     // unauthorized sender
     let msg = ExecuteMsg::Withdraw {
-        recipient: "addr0000".to_string(),
         amount: Uint128::new(1000),
     };
     require_error(
@@ -511,7 +510,6 @@ fn test_withdraw() -> TestResult {
 
     // withdraw more than unallocated
     let msg = ExecuteMsg::Withdraw {
-        recipient: "addr0000".to_string(),
         amount: Uint128::new(1001),
     };
     let res =
@@ -541,7 +539,6 @@ fn test_withdraw() -> TestResult {
 
     // withdraw but there's no more unallocated
     let msg = ExecuteMsg::Withdraw {
-        recipient: "addr0000".to_string(),
         amount: Uint128::new(1),
     };
     require_error(
@@ -797,7 +794,6 @@ fn claim_native() -> TestResult {
     // valid claim
     let info = mock_info("addr0001", &[]);
     let msg = ExecuteMsg::Claim {
-        recipient: None,
         denoms: vec![],
     };
 


### PR DESCRIPTION
- remove recipient from `Claim` msg and default to sender
- remove recipient from `Withdraw` msg and default to sender (who is also the admin)

BREAKING CHANGE: API breaking for `Withdraw`, but not for `Claim` because `recipient` was an Optional field. Doesn't matter for `Withdraw` because only the admin calls it on the backend. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Simplified the handling of claim and withdrawal operations in the token vesting contract.
- **Bug Fixes**
	- Adjusted recipient handling in withdrawal and claim functions for improved accuracy and security.
- **Tests**
	- Updated withdrawal and claim logic in tests to reflect changes in the contract functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->