### PR TITLE
feat(nibiru-std): Add Stargate protobuf query helper

### DIFF
--- a/nibiru-std/src/proto/traits.rs
+++ b/nibiru-std/src/proto/traits.rs
@@ -237,9 +237,7 @@ where
     Req: NibiruStargateQuery,
     Resp: prost::Message + Default,
 {
-    let query = req.into_stargate_query().map_err(|e| {
-        StdError::generic_err(format!("stargate query build error: {e}"))
-    })?;
+    let query = req.into_stargate_query()?;
     let raw_query = to_json_vec(&query)?;
 
     let response = match querier.raw_query(&raw_query) {

--- a/nibiru-std/src/proto/traits.rs
+++ b/nibiru-std/src/proto/traits.rs
@@ -7,7 +7,10 @@
 #![allow(deprecated)]
 // TODO: remove allow(deprevated) ↑
 
-use cosmwasm_std::{Binary, CosmosMsg, QueryRequest};
+use cosmwasm_std::{
+    to_json_vec, Binary, ContractResult, CosmosMsg, CustomQuery, QuerierWrapper,
+    QueryRequest, StdError, StdResult, SystemResult,
+};
 
 use crate::errors::{NibiruError, NibiruResult};
 
@@ -200,11 +203,144 @@ where
     }
 }
 
+/// Runs a Stargate query and decodes the protobuf response into a strong type.
+///
+/// `QuerierWrapper::query` decodes responses with serde JSON. Stargate query
+/// responses are protobuf bytes, so callers need the lower-level `raw_query`
+/// path followed by `prost::Message::decode`.
+///
+/// Contract usage should let Rust infer the request and querier types:
+///
+/// ```rust
+/// use cosmwasm_std::{Deps, StdResult};
+/// use nibiru_std::proto::{
+///     cosmos::bank::v1beta1::{QueryBalanceRequest, QueryBalanceResponse},
+///     query_stargate_proto,
+/// };
+///
+/// pub fn query_bank_balance(
+///     deps: Deps,
+///     address: String,
+///     denom: String,
+/// ) -> StdResult<QueryBalanceResponse> {
+///     let req = QueryBalanceRequest { address, denom };
+///     let resp: QueryBalanceResponse = query_stargate_proto(&deps.querier, &req)?;
+///     Ok(resp)
+/// }
+/// ```
+pub fn query_stargate_proto<C, Req, Resp>(
+    querier: &QuerierWrapper<C>,
+    req: &Req,
+) -> StdResult<Resp>
+where
+    C: CustomQuery,
+    Req: NibiruStargateQuery,
+    Resp: prost::Message + Default,
+{
+    let query = req.into_stargate_query().map_err(|e| {
+        StdError::generic_err(format!("stargate query build error: {e}"))
+    })?;
+    let raw_query = to_json_vec(&query)?;
+
+    let response = match querier.raw_query(&raw_query) {
+        SystemResult::Ok(ContractResult::Ok(response)) => response,
+        SystemResult::Ok(ContractResult::Err(err)) => {
+            return Err(StdError::generic_err(format!(
+                "stargate contract error: {err}"
+            )));
+        }
+        SystemResult::Err(err) => {
+            return Err(StdError::generic_err(format!(
+                "stargate system error: {err}"
+            )));
+        }
+    };
+
+    Resp::decode(response.as_slice()).map_err(|e| {
+        StdError::parse_err(std::any::type_name::<Resp>(), e.to_string())
+    })
+}
+
 impl From<cosmwasm_std::Coin> for cosmos::base::v1beta1::Coin {
     fn from(cw_coin: cosmwasm_std::Coin) -> Self {
         cosmos::base::v1beta1::Coin {
             denom: cw_coin.denom,
             amount: cw_coin.amount.to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cosmwasm_std::{
+        from_json, Binary, ContractResult, Empty, Querier, QuerierResult,
+        QuerierWrapper, QueryRequest, SystemError, SystemResult,
+    };
+    use prost::Message;
+
+    use super::{query_stargate_proto, NibiruStargateQuery};
+    use crate::proto::cosmos;
+
+    struct BankBalanceStargateQuerier {
+        expected_path: &'static str,
+        response: Binary,
+    }
+
+    impl Querier for BankBalanceStargateQuerier {
+        fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
+            let request: QueryRequest<Empty> = match from_json(bin_request) {
+                Ok(request) => request,
+                Err(err) => {
+                    return SystemResult::Err(SystemError::InvalidRequest {
+                        error: format!("parsing query request: {err}"),
+                        request: bin_request.into(),
+                    });
+                }
+            };
+
+            match request {
+                QueryRequest::Stargate { path, .. }
+                    if path == self.expected_path =>
+                {
+                    SystemResult::Ok(ContractResult::Ok(self.response.clone()))
+                }
+                _ => SystemResult::Err(SystemError::UnsupportedRequest {
+                    kind: "unexpected query".to_string(),
+                }),
+            }
+        }
+    }
+
+    #[test]
+    fn query_stargate_proto_decodes_bank_balance_response() {
+        let expected = cosmos::bank::v1beta1::QueryBalanceResponse {
+            balance: Some(cosmos::base::v1beta1::Coin {
+                denom: "unibi".to_string(),
+                amount: "123456".to_string(),
+            }),
+        };
+        let querier = BankBalanceStargateQuerier {
+            expected_path: "/cosmos.bank.v1beta1.Query/Balance",
+            response: Binary::from(expected.encode_to_vec()),
+        };
+        let wrapper = QuerierWrapper::<Empty>::new(&querier);
+
+        let req = cosmos::bank::v1beta1::QueryBalanceRequest {
+            address: "nibi1contract".to_string(),
+            denom: "unibi".to_string(),
+        };
+
+        let stargate_query = req
+            .into_stargate_query()
+            .expect("bank balance request should convert to Stargate");
+        assert!(matches!(
+            stargate_query,
+            QueryRequest::Stargate { ref path, .. }
+                if path == "/cosmos.bank.v1beta1.Query/Balance"
+        ));
+
+        let actual: cosmos::bank::v1beta1::QueryBalanceResponse =
+            query_stargate_proto(&wrapper, &req).unwrap();
+        assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
# Add Stargate Protobuf Query Helper

This adds a `nibiru-std` helper for contract code that needs to run Stargate queries and decode protobuf response bytes into generated strong response types, avoiding the serde JSON path that causes `DeserializeOwned` errors.

- Closes #147

## Key Changes

- Add `query_stargate_proto` beside the existing Stargate query traits so callers can pass `&deps.querier` and a generated protobuf request, then receive a generated protobuf response.
- Preserve the lower-level Stargate error shape by distinguishing system errors from contract errors before decoding successful protobuf bytes.
- Document the intended smart contract usage with a bank balance example that avoids explicit generic placeholders.
- Add a compile-tested bank `QueryBalanceRequest` to `QueryBalanceResponse` test using a fake Stargate querier with protobuf-encoded response bytes.

## Appendix

Tested with:

```bash
cargo test -p nibiru-std query_stargate_proto_decodes_bank_balance_response
```
